### PR TITLE
disable package lock locally

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,2 +1,1 @@
 8.7.0
-package-lock=false

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,2 @@
 8.7.0
+package-lock=false


### PR DESCRIPTION
adding "package-lock=false" in .nvmrc disables the package lock locally