### PR TITLE
Add a --likes flag (fixes #16)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,10 @@ const argv = yargs
   .help('h')
   .alias('h', 'help')
   .alias('v', 'version')
+  .option('likes', {
+    alias: 'l',
+    default: false
+  })
   .check(_argv => {
     const playListId = playList.getPlaylistId(_argv._[0]);
     if (!playListId) {
@@ -36,6 +40,25 @@ const main = async () => {
   const playListId = playList.getPlaylistId(argv._[0]);
   try {
     const videosList = await playList.getSortedPlaylist(playListId);
+
+    if (argv.likes) {
+      videosList.sort((a, b) => {
+          let aLikes = a.statistics.likeCount;
+          let bLikes = b.statistics.likeCount;
+
+          // In case likes are disabled for either video
+          if (isNaN(aLikes)) {
+              aLikes = 0;
+          }
+
+          if (isNaN(bLikes)) {
+              bLikes = 0;
+          }
+
+          return bLikes - aLikes;
+      });
+    }
+
     videosList.forEach(prettyPrintVideo);
   } catch (error) {
     if (error.response) {

--- a/src/index.js
+++ b/src/index.js
@@ -39,24 +39,12 @@ const argv = yargs
 const main = async () => {
   const playListId = playList.getPlaylistId(argv._[0]);
   try {
-    const videosList = await playList.getSortedPlaylist(playListId);
+    let videosList;
 
     if (argv.likes) {
-      videosList.sort((a, b) => {
-          let aLikes = a.statistics.likeCount;
-          let bLikes = b.statistics.likeCount;
-
-          // In case likes are disabled for either video
-          if (isNaN(aLikes)) {
-              aLikes = 0;
-          }
-
-          if (isNaN(bLikes)) {
-              bLikes = 0;
-          }
-
-          return bLikes - aLikes;
-      });
+      videosList = await playList.getSortedPlaylist(playListId, playList.likeComparator);
+    } else {
+      videosList = await playList.getSortedPlaylist(playListId);
     }
 
     videosList.forEach(prettyPrintVideo);

--- a/src/playlist.js
+++ b/src/playlist.js
@@ -4,13 +4,41 @@ const url = require('url');
 const api = require('./api');
 
 /**
- * Sorts descending based on viewCount / popularity
+ * Sorts descending based on a given property
  */
-function comparator(a, b) {
-  return b.statistics.viewCount - a.statistics.viewCount;
+function statisticsComparator(prop, a, b) {
+    let aProp = a.statistics[prop];
+    let bProp = b.statistics[prop];
+
+    if (isNaN(aProp)) {
+      aProp = 0;
+    }
+
+    if (isNaN(bProp)) {
+      bProp = 0;
+    }
+
+    return bProp - aProp;
 }
 
-async function getSortedPlaylist(playListId) {
+/**
+ * Sorts descending based on viewCount / popularity
+ */
+function viewComparator(a, b) {
+  return statisticsComparator('viewCount', a, b);
+}
+
+function likeComparator(a, b) {
+  return statisticsComparator('likeCount', a, b);
+}
+
+/**
+ * Returns a sorted playlist based on a given comparator.
+ * @param playListId
+ * @param {function} comparator - the comparator to sort by.
+ * @returns {Promise.<Array.<T>|*>}
+ */
+async function getSortedPlaylist(playListId, comparator = viewComparator) {
   const videoIds = await api.getVideoIdsFromPlayList(playListId);
   const videos = await Promise.all(videoIds.map(api.getVideoDetails));
   return videos.sort(comparator);
@@ -22,4 +50,4 @@ function getPlaylistId(playlistUrl) {
   return parsedUrl.query.list;
 }
 
-module.exports = { getSortedPlaylist, getPlaylistId };
+module.exports = { getSortedPlaylist, getPlaylistId, viewComparator, likeComparator };

--- a/src/playlist.js
+++ b/src/playlist.js
@@ -39,9 +39,13 @@ function likeComparator(a, b) {
  * @returns {Promise.<Array.<T>|*>}
  */
 async function getSortedPlaylist(playListId, comparator = viewComparator) {
-  const videoIds = await api.getVideoIdsFromPlayList(playListId);
-  const videos = await Promise.all(videoIds.map(api.getVideoDetails));
-  return videos.sort(comparator);
+  try {
+    const videoIds = await api.getVideoIdsFromPlayList(playListId);
+    const videos = await Promise.all(videoIds.map(api.getVideoDetails));
+    return videos.sort(comparator);
+  } catch (e) {
+    throw e;
+  }
 }
 
 function getPlaylistId(playlistUrl) {


### PR DESCRIPTION
This PR does a few things:
- Adds an option to `getSortedPlaylist` which allows custom comparators to be used 
- Adds a generic statistic comparator which should make it easier to add future comparators for video stats
- Adds a try/catch block around the `getSortedPlaylist` method because async functions don't catch failures in `await` calls
- Adds the requested `--likes` option to sort videos by likes (alias `-l`) (fixes #16 )